### PR TITLE
sessions disabledエラーを修正

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,4 +1,5 @@
 class ApplicationController < ActionController::API
+  include DeviseHackFakeSession
   include DeviseTokenAuth::Concerns::SetUserByToken
   before_action :configure_permitted_parameters, if: :devise_controller?
 

--- a/app/controllers/concerns/devise_hack_fake_session.rb
+++ b/app/controllers/concerns/devise_hack_fake_session.rb
@@ -1,0 +1,24 @@
+module DeviseHackFakeSession
+  extend ActiveSupport::Concern
+
+  class FakeSession < Hash
+    def enabled?
+      false
+    end
+
+    def destroy
+    end
+  end
+
+  included do
+    before_action :set_fake_session
+
+    private
+
+    def set_fake_session
+      if Rails.configuration.respond_to?(:api_only) && Rails.configuration.api_only
+        request.env['rack.session'] ||= ::DeviseHackFakeSession::FakeSession.new
+      end
+    end
+  end
+end


### PR DESCRIPTION
devise-auth-tokenのAPIを利用するときにsessions disabledエラーがでていたため修正。

[参考] https://blog.dnpp.org/api_only_rails7_with_devise